### PR TITLE
ci(mingw): only enable -municode for MinGW

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -13,8 +13,10 @@ if(USE_GCOV)
 endif()
 
 if(WIN32)
-  # tell MinGW compiler to enable wmain
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -municode")
+  if(MINGW)
+    # Enable wmain
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -municode")
+  endif()
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -framework CoreServices")
   set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -framework CoreServices")


### PR DESCRIPTION
When enabling -municode for MSVC the following warning shows up: "LINK : warning LNK4044: unrecognized option '/municode'; ignored". This will ensure cleaner logs for the MSVC job.